### PR TITLE
Improve gradle configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,11 @@ subprojects {
     def googleChecks = resources.text.fromArchiveEntry(configurations.checkstyle[0], 'google_checks.xml').asString()
 
     // set the location of the suppressions file referenced in google_checks.xml
-    configProperties['org.checkstyle.google.suppressionfilter.config'] = getConfigDirectory().file('checkstyle-suppressions.xml').get().toString()
+    def suppressionsChecks = '''
+        <module name="SuppressionFilter">
+            <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
+        </module>
+    '''
 
     // add in copyright header check on only java files (replace the last </module> in file)
     def copyrightChecks = '''
@@ -155,7 +159,7 @@ subprojects {
         </module>
     </module>
     '''
-    googleChecks = googleChecks.substring(0, googleChecks.lastIndexOf('</module>')) + copyrightChecks
+    googleChecks = googleChecks.substring(0, googleChecks.lastIndexOf('</module>')) + suppressionsChecks + copyrightChecks
 
     // this is the actual checkstyle config
     config = resources.text.fromString(googleChecks)

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ subprojects {
 
   // Use this to ensure we correctly override transitive dependencies
   // TODO: There might be a plugin that does this
-  task ensureTransitiveDependencyOverrides {
+  tasks.register("ensureTransitiveDependencyOverrides") {
     def dependenciesList = [dependencyStrings.GOOGLE_HTTP_CLIENT, dependencyStrings.GOOGLE_HTTP_CLIENT_APACHE_V2]
     def rules = dependenciesList.collectEntries{[/*name*/ it.split(':')[1], /*version*/ it.split(':')[2]]}
     doLast {
@@ -178,7 +178,7 @@ subprojects {
   }
   // jar to export tests classes for import in other project by doing:
   // testCompile project(path:':project-name', configuration:'tests')
-  task testJar(type: Jar) {
+  tasks.register("testJar", Jar) {
     from sourceSets.test.output.classesDirs
     classifier = 'tests'
   }
@@ -217,14 +217,14 @@ subprojects {
   }
 
   // Integration tests must be run explicitly
-  task integrationTest(type: Test) {
+  tasks.register("integrationTest", Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     systemProperty '_JIB_DISABLE_USER_AGENT', true
   }
 
 
-  task integrationTestJar(type: Jar) {
+  tasks.register("integrationTestJar", Jar) {
     from sourceSets.integrationTest.output.classesDirs
     classifier = 'integration-tests'
   }
@@ -278,14 +278,15 @@ subprojects {
   // for projects that release to maven central
   project.ext.configureMavenRelease = {
     apply plugin: 'maven-publish'
-    task sourceJar(type: Jar) {
+    tasks.register("sourceJar", Jar) {
       from sourceSets.main.allJava
       classifier 'sources'
     }
 
-    task javadocJar(type: Jar, dependsOn: javadoc) {
+    tasks.register("javadocJar", Jar) {
       from javadoc.destinationDir
       classifier 'javadoc'
+      dependsOn javadoc
     }
 
     publishing {
@@ -345,12 +346,12 @@ subprojects {
       destination = file("${project.buildDir}/pom/${project.name}-${project.version}.pom")
     }
     // define a special install task that handles installing locally for manual testing
-    task install {
+    tasks.register("install") {
       dependsOn publishToMavenLocal
     }
 
     // For kokoro sign and release to maven central
-    task prepareRelease(type: Copy) {
+    tasks.register("prepareRelease", Copy) {
       from jar
       from sourceJar
       from javadocJar

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -19,7 +19,7 @@ if (version.contains('SNAPSHOT')) {
     }
   }
 
-  task install {
+  tasks.register("install") {
     dependsOn publishToMavenLocal
   }
 }


### PR DESCRIPTION
### Improving Gradle configuration to make build faster

#### 1. First improvement is to update how checkstyle is configure

Cache is not relocatable due to config file defined with an absolute path.
- Usage of `getConfigDirectory()` to retrieve `checkstyle-suppressions.xml` file will retrieve an absolute path for this file.

The proposal is to inline the configuration, by `{config_loc}` that will give a relative path. Using that configuration be become `Cacheable` for next builds

 
#### 2. Second improvement is to update all tasks declaration by using `tasks.register()`

The proposal will defer task creation when is needed. It also align the code to use `tasks.register` for all defined tasks.

Here 2 build scans where you can see the improvement
- the first for [master branch (commit 92173ba6dbc3daadea68e4348e760e99d1e79783)](https://scans.gradle.com/s/lcog6r3f4nszy/performance/configuration/by-project?openProjects=WyJwcm9qZWN0LToiXQ#project-:!build.gradle), where you can see that during the `Configuration`, tasks for `build.gradle` are `Created immediately`.
<img width="647" alt="Screenshot 2023-01-18 at 10 25 50" src="https://user-images.githubusercontent.com/6226037/213150691-3556ae93-d6ee-4bd9-bf0b-d415bfcfeae8.png">

- on the other side for a scan on my PR branch [skurtzemann/improve-gradle-configuration (commit 711d770a2c496f2deb8c8d7426ecd0c13754b4e2)](https://scans.gradle.com/s/v65lzah73h2ia/performance/configuration/by-project?openProjects=WyJwcm9qZWN0LToiXQ#project-:!build.gradle) all `build.gradle` tasks are `Created during configuration`  
<img width="647" alt="Screenshot 2023-01-18 at 11 33 35" src="https://user-images.githubusercontent.com/6226037/213150728-7064eee3-6dfa-4057-bf93-93184576b6e7.png">


